### PR TITLE
Update thread_local to 1.1.7 to fix RUSTSEC-2022-0006

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2978,10 +2978,11 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.3"
+version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8018d24e04c95ac8790716a5987d0fec4f8b27249ffa0f7d33f1369bdfb88cbd"
+checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
 dependencies = [
+ "cfg-if 1.0.0",
  "once_cell",
 ]
 


### PR DESCRIPTION
The update fixes a data race in which was present in version 1.1.4 and earlier versions of `thread_local`. For more information see <https://rustsec.org/advisories/RUSTSEC-2022-0006>. This vulnerability is also known as GHSA-9hpw-r23r-xgm5.